### PR TITLE
Remove Trailing comma in literal

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -63,6 +63,3 @@ Style/MultilineBlockChain:
 
 Style/StringLiterals:
   Enabled: false
-
-Style/TrailingComma:
-  EnforcedStyleForMultiline: comma


### PR DESCRIPTION
This rule is deprecated and throws an error in Rubocop `0.39`
