### PR TITLE
Allow safe assignment idiom in conditions

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -12,6 +12,10 @@ Lint/EndAlignment:
   Enabled: true
   AlignWith: keyword
 
+Lint/AssignmentInCondition:
+  Enabled: true
+  AllowSafeAssignment: true
+
 Metrics/AbcSize:
   Enabled: false
 


### PR DESCRIPTION
Currently you get a warning when doing something like:

``` ruby
if abc = do_something
```

This will still do that but you can explicitly hint that you know that you're doing an assignment by putting brackets around the assignment.

``` ruby
if (abc = do_something)
```
